### PR TITLE
Attempting to fix nested bullets

### DIFF
--- a/manuscript/introduction.txt
+++ b/manuscript/introduction.txt
@@ -13,9 +13,9 @@ The following is a quick outline of some of the topics this book will cover:
 * Setting up a development environment
 * Web servers, Clack HTTP library and the various frameworks built on top of it.
 * Client side lisp
-** Lispy HTML/CSS/JavaScript
-** Using 3rd party APIs
-** Desktop apps
+    * Lispy HTML/CSS/JavaScript
+    * Using 3rd party APIs
+    * Desktop apps
 * DBs and ORMs
 * Very basic security and crypto
 * Deployment and management 


### PR DESCRIPTION
When `introduction.txt` is rendered on https://leanpub.com/fullstacklisp/read, lines 16 through 18 appear as part of line 15 instead of on their own lines.  I've attempted to fix this, but note that I'm doing it blindly, I haven't rendered the content after my changes... So please do that before accepting this change.